### PR TITLE
Version 1.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='easybash',
-    version='1.0.0',
+    version='1.0.1',
     author='André Luís',
     author_email='andreluisos@me.com',
     description='A Python shell command helper using the subprocess Popen.',


### PR DESCRIPTION
- Basher reads from pipe until the process exits. If the process produces enough output to fill the OS level pipe buffers, then it will deadlock. Solution is to consume the pipe data with an additional thread, as pipe checking is interrupted by poll.